### PR TITLE
[2018 day 18] Use `xrange` on Python 2

### DIFF
--- a/2018/day18/day18.py
+++ b/2018/day18/day18.py
@@ -10,6 +10,12 @@ from collections import Counter
 from operator import itemgetter
 
 
+try:
+    xrange
+except NameError:
+    xrange = range  # pylint: disable=invalid-name
+
+
 class LumberArea:
     """Represents an area for lumber collection."""
 
@@ -27,9 +33,9 @@ class LumberArea:
 
     def __str__(self):
         lines = []
-        for row_index in range(self.max_rows + 1):
+        for row_index in xrange(self.max_rows + 1):
             line = []
-            for cell_index in range(self.max_cells + 1):
+            for cell_index in xrange(self.max_cells + 1):
                 line.append(self.area[(row_index, cell_index)])
             lines.append(''.join(line))
 
@@ -42,8 +48,8 @@ class LumberArea:
     def execute_minute(self):
         """Executes a single minute of growth."""
         area_copy = self.area.copy()
-        for row_index in range(self.max_rows + 1):
-            for cell_index in range(self.max_cells + 1):
+        for row_index in xrange(self.max_rows + 1):
+            for cell_index in xrange(self.max_cells + 1):
                 position = (row_index, cell_index)
                 cell = self.area[position]
                 if cell == '.':
@@ -88,7 +94,7 @@ def run_part1(file_content):
     """Implmentation for Part 1."""
     area = LumberArea(file_content)
 
-    for _ in range(10):
+    for _ in xrange(10):
         area.execute_minute()
 
     counts = area.get_counts()
@@ -102,7 +108,7 @@ def run_part2(file_content):
     cycle_index = None
     cycle_patterns = []
 
-    for minute in range(1000000000):
+    for minute in xrange(1000000000):
         area.execute_minute()
 
         pattern = str(area)


### PR DESCRIPTION
On Python 2 `range` attempts to allocate memory to hold all values in
the range. Since this problem uses a very large `stop` value, the range
allocates so much memory that the OS kills it.